### PR TITLE
deps: migrate `faker` to `@faker-js/faker`

### DIFF
--- a/bin/faker-cli.js
+++ b/bin/faker-cli.js
@@ -83,8 +83,6 @@ function processOption(fakerMethod){
     printHelp(fakerMethod)
   }
 
-  fakerMethod = fakerMethod === 'names' ? 'name': fakerMethod;
-
   const methodData = getMethodOutput(fakerMethod, selectedMethod);
 
   log(JSON.stringify(methodData, null, 2))

--- a/bin/faker-cli.js
+++ b/bin/faker-cli.js
@@ -12,21 +12,28 @@ program
   .description('A cli wrapper for fakerjs')
   .usage('[option]')
   .option('-a, --address  [option]', 'Street address')
-  .option('-c, --company  [option]', 'Company info')
-  .option('-d, --date     [option]', 'Date options')
-  .option('-f  --finance  [option]', 'Finance field')
-  .option('-i  --internet [option]', 'Internet goodies')
-  .option('-l  --lorem    [option]', 'Lorem ipsum goodness')
-  .option('-n  --names    [option]', 'Person name(s)')
-  .option('-s  --system   [option]', 'System Info')
+  .option('-A, --animal   [option]', 'Want to build a farm?')
+  .option('--color        [option]', 'So beautiful')
   .option('-C  --commerce [option]', 'Commerce related info ')
-  .option('-p  --phone    [option]', 'Phone number options')
-  .option('-r  --random   [option]', 'Randomness')
-  .option('-L, --locale   [option]', 'Set locale, defaults to en', 'en')
+  .option('-c, --company  [option]', 'Company info')
+  .option('-D, --database [option]', 'Database stuff')
+  .option('-d, --date     [option]', 'Date options')
+  .option('-F  --faker    [option]', 'Fake everything')
+  .option('-f  --finance  [option]', 'Finance field')
+  .option('-g  --git      [option]', 'Git gud')
   .option('-x, --hacker   [option]', 'Hackers stuff')
   .option('-H, --helpers  [option]', 'Detailed contextual data')
   .option('-I, --image    [option]', 'Image data')
-  .option('-D, --database [option]', 'Database stuff')
+  .option('-i  --internet [option]', 'Internet goodies')
+  .option('-L, --locale   [option]', 'Set locale, defaults to en', 'en')
+  .option('-l  --lorem    [option]', 'Lorem ipsum goodness')
+  .option('-n  --name     [option]', 'Person name(s)')
+  .option('-p  --phone    [option]', 'Phone number options')
+  .option('-r  --random   [option]', 'Randomness')
+  .option('-S  --science  [option]', 'Science stuff')
+  .option('-s  --system   [option]', 'System Info')
+  .option('-v  --vehicle  [option]', 'Vehicle Info')
+  .option('-w  --word     [option]', 'In case you want to write a book')
   .option('--locales', 'List available locales');
 
 program.on('--help', function(){
@@ -34,9 +41,10 @@ program.on('--help', function(){
   log('');
   log('  Examples');
   log('');
-  log('\t$ faker-cli --helpers userCard');
+  log('\t$ faker-cli --git commitMessage');
   log('\t$ faker-cli --random uuid');
-  log('\t$ faker-cli --locale de -H userCard');
+  log('\t$ faker-cli --locale de --name firstName');
+  log('\t$ For a detailed list of all possible functions, visit https://fakerjs.dev');
   log('');
 });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // Load Module dependencies.
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 function getMethodFakerData(method, option) {
     if(method === 'locales') {

--- a/index.js
+++ b/index.js
@@ -25,23 +25,33 @@ module.exports.fields = function(which){
     return Object.keys(faker[which]);
 };
 
+/**
+ * @type {(keyof import('@faker-js/faker').Faker)[]}
+ */
 module.exports.fakerMethods = [
-    'names',
     'address',
-    'phone',
-    'internet',
-    'company',
-    'image',
-    'lorem',
-    'helpers',
-    'date',
-    'random',
-    'finance',
-    'hacker',
-    'locales',
-    'definitions',
-    'local',
-    'system',
+    'animal',
+    'color',
     'commerce',
-    'database'
+    'company',
+    'database',
+    'date',
+    'definitions',
+    'fake',
+    'finance',
+    'git',
+    'hacker',
+    'helpers',
+    'image',
+    'internet',
+    'locale',
+    'locales',
+    'lorem',
+    'name',
+    'phone',
+    'random',
+    'science',
+    'system',
+    'vehicle',
+    'word',
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@faker-js/faker": "^7.3.0",
         "commander": "^5.0.0",
-        "faker": "^4.1.0",
         "minimist": ">=1.2.2"
       },
       "bin": {
@@ -92,11 +91,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/faker": {
-      "version": "4.1.0",
-      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -334,11 +328,6 @@
       "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "faker": {
-      "version": "4.1.0",
-      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,286 @@
 {
   "name": "@itconnects/faker-cli",
   "version": "2.0.3",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@itconnects/faker-cli",
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@faker-js/faker": "^7.3.0",
+        "commander": "^5.0.0",
+        "faker": "^4.1.0",
+        "minimist": ">=1.2.2"
+      },
+      "bin": {
+        "faker-cli": "bin/faker-cli.js"
+      },
+      "devDependencies": {
+        "mocha": "^5.2.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
+      "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/commander/-/commander-5.0.0.tgz",
+      "integrity": "sha1-2/GQm0nlBE+P2vCtyAnwwHIr39A=",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/faker": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
+      "dev": true,
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
   "dependencies": {
+    "@faker-js/faker": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
+      "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://artifactory.figo.systems/artifactory/api/npm/virtual_npm/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/itconnects/faker-cli",
   "dependencies": {
+    "@faker-js/faker": "^7.3.0",
     "commander": "^5.0.0",
     "faker": "^4.1.0",
     "minimist": ">=1.2.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@faker-js/faker": "^7.3.0",
     "commander": "^5.0.0",
-    "faker": "^4.1.0",
     "minimist": ">=1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,
I'm one of the members of the "new", official fork of the old `faker` package (now [`faker-js/faker`](https://github.com/faker-js/faker)). 

If you are unaware of what happened to the old `faker` package,  we have a [TLDR on our website](https://fakerjs.dev/about/announcements/2022-01-14.html#i-heard-something-happened-what-s-the-tldr).

Since the newest version of that now deprecated `faker` package is corrupted we try to help people migrate away from it, so it doesn't get the traffic anymore.

Because of that, I provided a PR that updates your "old" `faker` package with our newest, official package.

If you have any questions or are unhappy with my implementations just leave a comment and I will adapt.