### PR TITLE
docs(README): fix faker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NPM](https://nodei.co/npm/faker-cli.png?downloads=true&stars=true)](https://nodei.co/npm/faker-cli/)
 
-A command-line wrapper for [faker](https://github.com/marak/Faker.js)
+A command-line wrapper for [faker](https://github.com/faker-js/faker)
 
 # Install.
 


### PR DESCRIPTION
Updates the link in the [README](https://github.com/lestoni/faker-cli/blob/master/README.md) file to the correct GitHub repository.